### PR TITLE
FIX Use canDelete instead of removed canArchive for CMS 6 compatibility

### DIFF
--- a/src/Model/BaseElementObject.php
+++ b/src/Model/BaseElementObject.php
@@ -229,8 +229,7 @@ class BaseElementObject extends DataObject
         }
 
         if ($page = $this->getPage()) {
-            // @phpstan-ignore-next-line
-            return $page->canArchive($member);
+            return $page->canDelete($member);
         }
 
         return Permission::check('CMS_ACCESS', 'any', $member);


### PR DESCRIPTION
Versioned::canArchive() was deprecated in Silverstripe CMS 5.3.0 and removed in CMS 6.0.0.

Tested in a production CMS 6.1 project.