### PR TITLE
fix: SS6 namespace move — ValidationResult

### DIFF
--- a/src/Model/BaseElementObject.php
+++ b/src/Model/BaseElementObject.php
@@ -11,7 +11,7 @@ use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Security\Permission;
 use SilverStripe\Versioned\Versioned;
-use SilverStripe\ORM\ValidationResult;
+use SilverStripe\Core\Validation\ValidationResult;
 use SilverStripe\LinkField\Models\Link;
 use SilverStripe\LinkField\Form\LinkField;
 use DNADesign\Elemental\Models\BaseElement;


### PR DESCRIPTION
## Summary
- `SilverStripe\ORM\ValidationResult` → `SilverStripe\Core\Validation\ValidationResult` (BaseElementObject)

Class moved in SilverStripe 6. Caught by PHPStan audit across the full Essentials suite.

## Test plan
- [ ] `ddev sake dev/build flush=1` passes (verified in testbed)
- [ ] PHPStan reports no errors on this file